### PR TITLE
Add portable venv python helper

### DIFF
--- a/boot_system.py
+++ b/boot_system.py
@@ -3,10 +3,11 @@ import subprocess
 import os
 import sys
 import time
+from manager_utils import get_venv_python
 
 # --- Configuration ---
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__)) # Assumes boot_system.py is in n0m1_agi
-VENV_PYTHON_PATH = os.path.join(PROJECT_DIR, 'venv', 'bin', 'python')
+VENV_PYTHON_PATH = get_venv_python(PROJECT_DIR)
 
 # Define the manager scripts to be launched
 # We assume these manager scripts, when run, will start their respective components.

--- a/boot_system_enhanced.py
+++ b/boot_system_enhanced.py
@@ -11,10 +11,11 @@ import json
 import sqlite3
 from datetime import datetime
 from typing import Dict, List, Optional
+from manager_utils import get_venv_python
 
 # --- Configuration ---
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
-VENV_PYTHON_PATH = os.path.join(PROJECT_DIR, 'venv', 'bin', 'python')
+VENV_PYTHON_PATH = get_venv_python(PROJECT_DIR)
 CONFIG_FILE = os.path.join(PROJECT_DIR, 'config.json')
 DB_FILE_NAME = 'n0m1_agi.db'
 DB_FULL_PATH = os.path.expanduser(f'~/n0m1_agi/{DB_FILE_NAME}')

--- a/daemon_manager.py
+++ b/daemon_manager.py
@@ -14,18 +14,19 @@ import signal
 import sqlite3
 import json
 from manager_utils import (
+    get_venv_python,
     get_pid_file_path,
     is_process_running,
     read_pid_file,
     write_pid_file,
     remove_pid_file,
     log_lifecycle_event,
-    create_required_directories
+    create_required_directories,
 )
 
 # --- Configuration ---
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
-VENV_PYTHON_PATH = os.path.join(PROJECT_DIR, 'venv', 'bin', 'python')
+VENV_PYTHON_PATH = get_venv_python(PROJECT_DIR)
 PID_DIR = os.path.join(PROJECT_DIR, 'pids')
 LOGS_DIR = os.path.join(PROJECT_DIR, 'logs')
 

--- a/main_llm_manager.py
+++ b/main_llm_manager.py
@@ -7,10 +7,11 @@ import argparse
 import signal
 import sqlite3
 import json
+from manager_utils import get_venv_python
 
 # --- Configuration ---
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
-VENV_PYTHON_PATH = os.path.join(PROJECT_DIR, 'venv', 'bin', 'python')
+VENV_PYTHON_PATH = get_venv_python(PROJECT_DIR)
 PID_DIR = os.path.join(PROJECT_DIR, 'pids')
 LOGS_DIR = os.path.join(PROJECT_DIR, 'logs') # For the llm_processor.py logs
 

--- a/manager_utils.py
+++ b/manager_utils.py
@@ -9,6 +9,13 @@ import time
 import sqlite3
 from typing import Optional, Tuple
 
+
+def get_venv_python(project_dir: str) -> str:
+    """Return path to the virtual environment Python interpreter."""
+    if os.name == "nt":
+        return os.path.join(project_dir, "venv", "Scripts", "python.exe")
+    return os.path.join(project_dir, "venv", "bin", "python")
+
 def get_pid_file_path(pid_dir: str, component_id: str) -> str:
     """Get the PID file path for a component."""
     return os.path.join(pid_dir, f"{component_id}.pid")

--- a/n0m1_control.py
+++ b/n0m1_control.py
@@ -11,12 +11,13 @@ import subprocess
 import sqlite3
 import json
 import argparse
+from manager_utils import get_venv_python
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional, Tuple
 
 # --- Configuration ---
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
-VENV_PYTHON_PATH = os.path.join(PROJECT_DIR, 'venv', 'bin', 'python')
+VENV_PYTHON_PATH = get_venv_python(PROJECT_DIR)
 DB_FILE_NAME = 'n0m1_agi.db'
 DB_FULL_PATH = os.path.expanduser(f'~/n0m1_agi/{DB_FILE_NAME}')
 BOOT_PID_FILE = os.path.join(PROJECT_DIR, "pids", "boot_system.pid")

--- a/nano_manager.py
+++ b/nano_manager.py
@@ -7,10 +7,11 @@ import argparse
 import signal
 import sqlite3
 import json
+from manager_utils import get_venv_python
 
 # --- Configuration ---
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
-VENV_PYTHON_PATH = os.path.join(PROJECT_DIR, 'venv', 'bin', 'python')
+VENV_PYTHON_PATH = get_venv_python(PROJECT_DIR)
 PID_DIR = os.path.join(PROJECT_DIR, 'pids')
 LOGS_DIR = os.path.join(PROJECT_DIR, 'logs')
 


### PR DESCRIPTION
## Summary
- add `get_venv_python` utility
- use helper when spawning python subprocesses in controllers and managers

## Testing
- `python3 -m py_compile boot_system.py boot_system_enhanced.py daemon_manager.py nano_manager.py main_llm_manager.py n0m1_control.py manager_utils.py temp_main_daemon.py init_database.py`

------
https://chatgpt.com/codex/tasks/task_e_68812842c2c8832e95eec4af29566c1c