### PR TITLE
Add cross-platform system metrics daemon

### DIFF
--- a/ClaudeREADME.md
+++ b/ClaudeREADME.md
@@ -9,12 +9,17 @@ n0m1_agi/
 ├── manager_utils.py           # Shared utilities
 ├── init_database.py           # Database initialization
 ├── n0m1_control.py           # System control interface
-├── temp_main_daemon.py        # Example daemon (fixed)
+├── temp_main_daemon.py        # macOS-only temperature daemon
+├── system_metrics_daemon.py   # Cross-platform system metrics daemon
 ├── config.json               # Optional configuration
 ├── n0m1_agi.db              # SQLite database
 ├── logs/                     # Component logs
 ├── logs_managers/            # Manager logs
 └── pids/                     # PID files
+
+The new `system_metrics_daemon.py` collects CPU temperature (using macOS SMC on
+Darwin or `psutil` on Linux/Windows), CPU usage, and memory usage and stores the
+data in the `system_metrics_log` table.
 Quick Start
 1. Initial Setup
 bash# Create virtual environment
@@ -22,7 +27,7 @@ python3 -m venv venv
 source venv/bin/activate
 
 # Install dependencies (if any)
-# pip install -r requirements.txt
+pip install psutil
 
 # Initialize database
 ./init_database.py
@@ -46,13 +51,13 @@ chmod +x n0m1_control.py
 ./n0m1_control.py restart
 3. Component Management
 bash# Enable a component
-./n0m1_control.py enable temp_main_daemon
+./n0m1_control.py enable system_metrics_daemon
 
 # Disable a component
 ./n0m1_control.py disable nano_analyzer_01
 
 # View component logs
-./n0m1_control.py logs temp_main_daemon
+./n0m1_control.py logs system_metrics_daemon
 
 # Follow logs in real-time
 ./n0m1_control.py logs -f daemon_manager
@@ -62,6 +67,7 @@ Key Improvements
 Fixed typo in temp_main_daemon.py (annce_startup → announce_startup)
 Completed implementation of stop_component() functions
 Added proper error handling throughout
+Added system_metrics_daemon for cross-platform CPU and memory metrics
 
 2. Database Management
 
@@ -112,6 +118,8 @@ Timestamps and PIDs
 
 cpu_temperature_log
 Example data table for the temperature daemon
+system_metrics_log
+Cross-platform metrics collected by system_metrics_daemon
 Configuration
 Optional config.json
 json{

--- a/init_database.py
+++ b/init_database.py
@@ -67,6 +67,17 @@ def create_database_schema():
                 temperature_celsius REAL NOT NULL
             );
         """)
+
+        # 4. system_metrics_log table - Generic system metrics
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS system_metrics_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                cpu_temp REAL,
+                cpu_usage REAL NOT NULL,
+                mem_usage REAL NOT NULL
+            );
+        """)
         
         # Create indexes for better performance
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_ac_manager ON autorun_components (manager_affinity);")
@@ -75,6 +86,7 @@ def create_database_schema():
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_cll_event_type ON component_lifecycle_log (event_type);")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_cll_timestamp ON component_lifecycle_log (event_timestamp);")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_temp_timestamp ON cpu_temperature_log (timestamp);")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_metrics_timestamp ON system_metrics_log (timestamp);")
         
         # Create trigger to update modified_timestamp
         cursor.execute("""
@@ -116,6 +128,15 @@ def populate_default_components():
                 'launch_args_json': '{}',
                 'run_type_on_boot': 'PRIMARY_RUN',
                 'description': 'CPU temperature monitoring daemon'
+            },
+            {
+                'component_id': 'system_metrics_daemon',
+                'base_script_name': 'system_metrics_daemon.py',
+                'manager_affinity': 'daemon_manager',
+                'desired_state': 'active',
+                'launch_args_json': '{}',
+                'run_type_on_boot': 'PRIMARY_RUN',
+                'description': 'Cross-platform system metrics collector'
             },
             {
                 'component_id': 'main_llm_processor',

--- a/system_metrics_daemon.py
+++ b/system_metrics_daemon.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Cross-platform system metrics daemon."""
+import time
+import os
+import sqlite3
+import argparse
+import platform
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+from manager_utils import log_lifecycle_event
+
+# --- Configuration ---
+DB_FILE_NAME = 'n0m1_agi.db'
+DB_FULL_PATH = os.path.expanduser(f'~/n0m1_agi/{DB_FILE_NAME}')
+TABLE_NAME = 'system_metrics_log'
+LIFECYCLE_TABLE_NAME = 'component_lifecycle_log'
+COMPONENT_ID = 'system_metrics_daemon'
+POLLING_INTERVAL_SECONDS = 10
+# --- End Configuration ---
+
+# Import macOS temperature helper if available
+if platform.system() == 'Darwin':
+    try:
+        from temp_main_daemon import get_smc_cpu_temp
+    except Exception:
+        get_smc_cpu_temp = None
+else:
+    get_smc_cpu_temp = None
+
+
+def read_cpu_temp():
+    """Return CPU temperature if available."""
+    if platform.system() == 'Darwin' and get_smc_cpu_temp:
+        try:
+            return get_smc_cpu_temp()
+        except Exception:
+            return None
+
+    if psutil and hasattr(psutil, 'sensors_temperatures'):
+        try:
+            temps = psutil.sensors_temperatures()
+            if not temps:
+                return None
+            # look for common keys
+            for key in ('coretemp', 'cpu-thermal', 'k10temp'):
+                if key in temps and temps[key]:
+                    return temps[key][0].current
+            # fallback to first entry
+            for entries in temps.values():
+                if entries:
+                    return entries[0].current
+        except Exception:
+            return None
+    return None
+
+
+def read_cpu_usage():
+    if psutil:
+        try:
+            return psutil.cpu_percent(interval=None)
+        except Exception:
+            return None
+    return None
+
+
+def read_mem_usage():
+    if psutil:
+        try:
+            return psutil.virtual_memory().percent
+        except Exception:
+            return None
+    return None
+
+
+def log_start(run_type):
+    log_lifecycle_event(
+        DB_FULL_PATH,
+        LIFECYCLE_TABLE_NAME,
+        COMPONENT_ID,
+        os.getpid(),
+        'STARTED_SUCCESSFULLY',
+        run_type,
+        'System metrics daemon started',
+        COMPONENT_ID,
+        os.path.abspath(__file__),
+    )
+
+
+def log_stop(run_type, message):
+    log_lifecycle_event(
+        DB_FULL_PATH,
+        LIFECYCLE_TABLE_NAME,
+        COMPONENT_ID,
+        os.getpid(),
+        'STOPPED',
+        run_type,
+        message,
+        COMPONENT_ID,
+        os.path.abspath(__file__),
+    )
+
+
+def main_loop(run_type):
+    conn = sqlite3.connect(DB_FULL_PATH)
+    cursor = conn.cursor()
+    while True:
+        temp = read_cpu_temp()
+        cpu = read_cpu_usage()
+        mem = read_mem_usage()
+        cursor.execute(
+            f"INSERT INTO {TABLE_NAME} (cpu_temp, cpu_usage, mem_usage) VALUES (?, ?, ?)",
+            (temp, cpu, mem),
+        )
+        conn.commit()
+        print(f"[{COMPONENT_ID}] CPU {cpu}% MEM {mem}% TEMP {temp}")
+        time.sleep(POLLING_INTERVAL_SECONDS)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='System metrics daemon')
+    parser.add_argument('--run_type', type=str, default='MANUAL_RUN')
+    args = parser.parse_args()
+
+    log_start(args.run_type)
+    try:
+        main_loop(args.run_type)
+    except KeyboardInterrupt:
+        log_stop(args.run_type, 'Stopped via KeyboardInterrupt')
+    except Exception as e:
+        log_stop(args.run_type, f'Unexpected error: {e}')
+    finally:
+        pass
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `system_metrics_daemon.py` to collect CPU temp/usage and memory usage
- add `system_metrics_log` table and default config entry in `init_database.py`
- hook daemon into default autorun list
- document new daemon and update instructions

## Testing
- `python3 -m py_compile system_metrics_daemon.py init_database.py temp_main_daemon.py daemon_manager.py boot_system_enhanced.py manager_utils.py n0m1_control.py nano_manager.py main_llm_manager.py boot_system.py`

------
https://chatgpt.com/codex/tasks/task_e_68812b2399cc832e91c96ffce4ade94c