### PR TITLE
Add tests for manager_utils helpers

### DIFF
--- a/tests/test_manager_utils.py
+++ b/tests/test_manager_utils.py
@@ -1,0 +1,37 @@
+import os
+import tempfile
+import subprocess
+import sys
+import time
+
+import pytest
+
+# Ensure the project root is on sys.path so manager_utils can be imported
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from manager_utils import write_pid_file, read_pid_file, is_process_running
+
+
+def test_write_and_read_pid_file_roundtrip(tmp_path):
+    pid_file = tmp_path / "test.pid"
+    pid = 12345
+    assert write_pid_file(str(pid_file), pid)
+    assert read_pid_file(str(pid_file)) == pid
+
+
+def test_read_pid_file_invalid(tmp_path):
+    pid_file = tmp_path / "invalid.pid"
+    pid_file.write_text("notanumber")
+    assert read_pid_file(str(pid_file)) is None
+    assert read_pid_file(str(pid_file.with_suffix('.missing')) ) is None
+
+
+def test_is_process_running_for_running_and_stopped_process():
+    proc = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(2)"])
+    try:
+        assert is_process_running(proc.pid)
+    finally:
+        proc.terminate()
+        proc.wait()
+    # After process termination, it should report not running
+    assert not is_process_running(proc.pid)


### PR DESCRIPTION
## Summary
- add pytest-based tests for PID helpers and process check in `manager_utils`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812af86994832eb07562b86ce29859