### PR TITLE
Allow native Python override

### DIFF
--- a/ClaudeREADME.md
+++ b/ClaudeREADME.md
@@ -29,6 +29,9 @@ source venv/bin/activate
 # Install dependencies (if any)
 pip install psutil
 
+# Tip: set N0M1_NATIVE=1 to run managers with the current Python interpreter
+# rather than the virtual environment. Useful for testing without a venv.
+
 # Initialize database
 ./init_database.py
 2. System Control

--- a/manager_utils.py
+++ b/manager_utils.py
@@ -7,11 +7,21 @@ import os
 import signal
 import time
 import sqlite3
+import sys
 from typing import Optional, Tuple
 
 
 def get_venv_python(project_dir: str) -> str:
-    """Return path to the virtual environment Python interpreter."""
+    """Return path to the virtual environment Python interpreter.
+
+    If the environment variable ``N0M1_NATIVE`` is set to ``1`` or ``true``,
+    the path to the running Python interpreter (``sys.executable``) is
+    returned instead. This allows the managers to run natively on systems
+    without a dedicated virtual environment.
+    """
+    if os.environ.get("N0M1_NATIVE", "").lower() in {"1", "true", "yes"}:
+        return sys.executable
+
     if os.name == "nt":
         return os.path.join(project_dir, "venv", "Scripts", "python.exe")
     return os.path.join(project_dir, "venv", "bin", "python")

--- a/tests/test_manager_utils.py
+++ b/tests/test_manager_utils.py
@@ -9,7 +9,12 @@ import pytest
 # Ensure the project root is on sys.path so manager_utils can be imported
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from manager_utils import write_pid_file, read_pid_file, is_process_running
+from manager_utils import (
+    write_pid_file,
+    read_pid_file,
+    is_process_running,
+    get_venv_python,
+)
 
 
 def test_write_and_read_pid_file_roundtrip(tmp_path):
@@ -35,3 +40,11 @@ def test_is_process_running_for_running_and_stopped_process():
         proc.wait()
     # After process termination, it should report not running
     assert not is_process_running(proc.pid)
+
+
+def test_get_venv_python_native_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("N0M1_NATIVE", "1")
+    path = get_venv_python(str(tmp_path))
+    assert path == sys.executable
+    monkeypatch.delenv("N0M1_NATIVE", raising=False)
+


### PR DESCRIPTION
## Summary
- add `N0M1_NATIVE` environment variable support in `get_venv_python`
- document native option in README
- test `get_venv_python` behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68812fa1cf9c832ea644d938bf8369a0