### PR TITLE
Add system metrics CLI command

### DIFF
--- a/ClaudeREADME.md
+++ b/ClaudeREADME.md
@@ -52,6 +52,9 @@ chmod +x n0m1_control.py
 
 # Restart the system
 ./n0m1_control.py restart
+
+# View recent system metrics
+./n0m1_control.py metrics --limit 5
 3. Component Management
 bash# Enable a component
 ./n0m1_control.py enable system_metrics_daemon


### PR DESCRIPTION
## Summary
- extend `n0m1_control.py` with a `metrics` command
- show latest and average CPU, memory and temperature statistics
- update CLI help examples
- document metrics command in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688131e15b38832e8e0691704d523d40