### PR TITLE
Implement stop_component with manager_utils helper

### DIFF
--- a/nano_manager.py
+++ b/nano_manager.py
@@ -7,7 +7,13 @@ import argparse
 import signal
 import sqlite3
 import json
-from manager_utils import get_venv_python
+from manager_utils import (
+    get_venv_python,
+    read_pid_file,
+    remove_pid_file,
+    stop_component_with_timeout,
+    log_lifecycle_event,
+)
 
 # --- Configuration ---
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -103,11 +109,38 @@ def start_component(component_id, base_script_name, launch_args_list, run_type):
         return False
 
 def stop_component(component_id, signal_to_send=signal.SIGTERM):
-    # This function should be identical to stop_daemon in daemon_manager.py
-    # (or stop_service from system_manager.py, adapted for component_id)
-    # For brevity, assuming it's copied and works.
-    # It should also log to component_lifecycle_log events like 'STOP_REQUESTED', 'STOPPED_SUCCESSFULLY'
-    print(f"[{MANAGER_ID}] Placeholder: stop_component({component_id}) called.")
+    """Stop a running nano component by PID file."""
+    pid_file = get_pid_file_path(component_id)
+    pid = read_pid_file(pid_file)
+
+    if not pid or not is_process_running(pid):
+        log_lifecycle_event(
+            DB_FULL_PATH,
+            LIFECYCLE_TABLE_NAME,
+            component_id,
+            pid,
+            'STOPPED_SUCCESSFULLY',
+            None,
+            'Already stopped',
+            MANAGER_ID,
+        )
+        remove_pid_file(pid_file)
+        print(f"[{MANAGER_ID}] Component '{component_id}' already stopped.")
+        return True
+
+    result = stop_component_with_timeout(
+        component_id,
+        pid,
+        MANAGER_ID,
+        LIFECYCLE_TABLE_NAME,
+        DB_FULL_PATH,
+        timeout_seconds=10,
+        signal_to_send=signal_to_send,
+    )
+
+    if result:
+        remove_pid_file(pid_file)
+    return result
 
 
 def get_component_status(component_id):

--- a/tests/test_stop_components.py
+++ b/tests/test_stop_components.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import sqlite3
+import subprocess
+import time
+
+import pytest
+
+# Add project root to path so managers can be imported
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import nano_manager
+import main_llm_manager
+
+
+def _setup_db(path):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE component_lifecycle_log (id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " event_timestamp TEXT, component_id TEXT, process_pid INTEGER, event_type TEXT,"
+        " run_type TEXT, message TEXT, manager_script TEXT, script_path TEXT)"
+    )
+    conn.commit()
+    conn.close()
+
+
+def _launch_dummy_process():
+    return subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"])
+
+
+@pytest.mark.parametrize("module", [nano_manager, main_llm_manager])
+def test_stop_component_terminates_process(tmp_path, module):
+    pid_dir = tmp_path / "pids"
+    pid_dir.mkdir()
+    db_path = tmp_path / "test.db"
+    _setup_db(str(db_path))
+
+    module.PID_DIR = str(pid_dir)
+    module.DB_FULL_PATH = str(db_path)
+
+    proc = _launch_dummy_process()
+    pid_file = pid_dir / f"dummy.pid"
+    pid_file.write_text(str(proc.pid))
+
+    try:
+        module.stop_component("dummy")
+        # allow some time for process to terminate and reap it
+        proc.wait(timeout=5)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+    assert proc.poll() is not None
+


### PR DESCRIPTION
## Summary
- hook up stop_component for nano_manager and main_llm_manager
- record lifecycle events when stopping components
- add tests ensuring dummy processes can be terminated by both managers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688131e38f04832eaf24e56ac74ab443