### PR TITLE
Add nano_outputs table and summary logging

### DIFF
--- a/init_database.py
+++ b/init_database.py
@@ -78,6 +78,18 @@ def create_database_schema():
                 mem_usage REAL NOT NULL
             );
         """)
+
+        # 5. nano_outputs table - Stores nano instance generated summaries
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS nano_outputs (
+                id INTEGER PRIMARY KEY,
+                nano_id TEXT,
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                content TEXT
+            );
+            """
+        )
         
         # Create indexes for better performance
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_ac_manager ON autorun_components (manager_affinity);")

--- a/tests/test_nano_instance.py
+++ b/tests/test_nano_instance.py
@@ -1,0 +1,78 @@
+import os
+import sqlite3
+import sys
+import pytest
+
+# Add repo root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import nano_instance
+
+
+def setup_test_db(tmp_path):
+    db_path = tmp_path / "nano.db"
+    conn = sqlite3.connect(db_path)
+    # component_lifecycle_log required for log_lifecycle_event
+    conn.execute(
+        """CREATE TABLE component_lifecycle_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+            component_id TEXT NOT NULL,
+            process_pid INTEGER,
+            event_type TEXT NOT NULL,
+            run_type TEXT,
+            message TEXT,
+            manager_script TEXT,
+            script_path TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE system_metrics_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+            cpu_temp REAL,
+            cpu_usage REAL NOT NULL,
+            mem_usage REAL NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE nano_outputs (
+            id INTEGER PRIMARY KEY,
+            nano_id TEXT,
+            timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            content TEXT
+        )"""
+    )
+    # insert a metrics row with high temperature
+    conn.execute(
+        "INSERT INTO system_metrics_log (cpu_temp, cpu_usage, mem_usage) VALUES (85, 1, 1)"
+    )
+    conn.commit()
+    conn.close()
+    return str(db_path)
+
+
+def test_nano_instance_writes_output(tmp_path, monkeypatch):
+    db_path = setup_test_db(tmp_path)
+
+    monkeypatch.setattr(nano_instance, "DB_FULL_PATH", db_path)
+
+    # speed up loop
+    monkeypatch.setattr(nano_instance, "METRICS_TABLE", "system_metrics_log")
+
+    def fake_sleep(_):
+        raise StopIteration
+
+    monkeypatch.setattr(nano_instance.time, "sleep", fake_sleep)
+    monkeypatch.setattr(sys, "argv", ["nano_instance.py"])
+
+    with pytest.raises(StopIteration):
+        nano_instance.main()
+
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM nano_outputs")
+    count = cur.fetchone()[0]
+    conn.close()
+
+    assert count >= 1


### PR DESCRIPTION
## Summary
- create `nano_outputs` table in `init_database.py`
- write metrics summaries from `nano_instance.py`
- add tests for nano instance output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813d449fe4832eaf7081b1199176ca