### PR TITLE
Add LLM configuration daemon and schema

### DIFF
--- a/ClaudeREADME.md
+++ b/ClaudeREADME.md
@@ -190,6 +190,16 @@ To enable these components, insert or update records in the
 `launch_args_json` values. When the system starts, the managers will read the
 table and launch the configured models.
 
+Configuring the Main LLM
+------------------------
+The tables ``llm_io_config`` and ``llm_notifications`` allow runtime control of
+the main language model. ``llm_io_config`` stores comma-separated input tables
+and the output table for each LLM. Set ``needs_reload`` to ``1`` to signal a
+configuration change. The ``llm_config_daemon`` will write a ``CONFIG_RELOAD``
+notification to ``llm_notifications`` which causes ``llm_processor`` to reload
+its settings. A ``RUN`` notification instructs the processor to read from the
+allowed tables and write results to the designated output table.
+
 Custom Managers
 Managers should:
 

--- a/llm_config_daemon.py
+++ b/llm_config_daemon.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Daemon that monitors LLM configuration changes.
+
+This daemon watches the ``llm_io_config`` table for updates and writes
+rows to ``llm_notifications`` when a reload is requested.
+"""
+import argparse
+import os
+import sqlite3
+import time
+
+from manager_utils import log_lifecycle_event
+
+DB_FILE_NAME = 'n0m1_agi.db'
+DB_FULL_PATH = os.path.expanduser(f'~/n0m1_agi/{DB_FILE_NAME}')
+CONFIG_TABLE = 'llm_io_config'
+NOTIFY_TABLE = 'llm_notifications'
+LIFECYCLE_TABLE = 'component_lifecycle_log'
+COMPONENT_ID = 'llm_config_daemon'
+POLL_INTERVAL = 5
+
+
+def log_start(run_type: str):
+    log_lifecycle_event(
+        DB_FULL_PATH,
+        LIFECYCLE_TABLE,
+        COMPONENT_ID,
+        os.getpid(),
+        'STARTED_SUCCESSFULLY',
+        run_type,
+        'LLM config daemon started',
+        COMPONENT_ID,
+        os.path.abspath(__file__),
+    )
+
+
+def log_stop(run_type: str, message: str):
+    log_lifecycle_event(
+        DB_FULL_PATH,
+        LIFECYCLE_TABLE,
+        COMPONENT_ID,
+        os.getpid(),
+        'STOPPED',
+        run_type,
+        message,
+        COMPONENT_ID,
+        os.path.abspath(__file__),
+    )
+
+
+def main_loop(run_type: str):
+    conn = sqlite3.connect(DB_FULL_PATH)
+    cur = conn.cursor()
+    while True:
+        cur.execute(
+            f"SELECT needs_reload FROM {CONFIG_TABLE} WHERE llm_id=?",
+            ('main_llm_processor',),
+        )
+        row = cur.fetchone()
+        if row and row[0]:
+            cur.execute(
+                f"INSERT INTO {NOTIFY_TABLE} (llm_id, notification_type) VALUES (?, ?)",
+                ('main_llm_processor', 'CONFIG_RELOAD'),
+            )
+            cur.execute(
+                f"UPDATE {CONFIG_TABLE} SET needs_reload=0 WHERE llm_id=?",
+                ('main_llm_processor',),
+            )
+            conn.commit()
+        time.sleep(POLL_INTERVAL)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='LLM configuration daemon')
+    parser.add_argument('--run_type', default='MANUAL_RUN')
+    args = parser.parse_args()
+
+    log_start(args.run_type)
+    try:
+        main_loop(args.run_type)
+    except KeyboardInterrupt:
+        log_stop(args.run_type, 'Stopped via KeyboardInterrupt')
+    except Exception as e:  # pragma: no cover - unexpected errors
+        log_stop(args.run_type, f'Unexpected error: {e}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_llm_config.py
+++ b/tests/test_llm_config.py
@@ -1,0 +1,100 @@
+import os
+import sqlite3
+import sys
+import types
+import importlib
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import llm_config_daemon
+import llm_processor
+
+
+def setup_db(tmp_path):
+    db = tmp_path / "test.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """CREATE TABLE llm_io_config (
+            llm_id TEXT PRIMARY KEY,
+            read_tables TEXT,
+            output_table TEXT,
+            needs_reload INTEGER
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE llm_notifications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            llm_id TEXT,
+            notification_type TEXT,
+            processed INTEGER DEFAULT 0,
+            created_timestamp TEXT DEFAULT CURRENT_TIMESTAMP
+        )"""
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_llm_config_daemon_updates_notification(tmp_path, monkeypatch):
+    db = setup_db(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO llm_io_config (llm_id, read_tables, output_table, needs_reload) VALUES ('main_llm_processor', 'input', 'results', 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(llm_config_daemon, "DB_FULL_PATH", str(db))
+    monkeypatch.setattr(llm_config_daemon, "POLL_INTERVAL", 0)
+
+    def fake_sleep(_):
+        raise StopIteration
+
+    monkeypatch.setattr(llm_config_daemon.time, "sleep", fake_sleep)
+
+    with pytest.raises(StopIteration):
+        llm_config_daemon.main_loop("TEST")
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT needs_reload FROM llm_io_config WHERE llm_id='main_llm_processor'")
+    assert cur.fetchone()[0] == 0
+    cur.execute("SELECT COUNT(*) FROM llm_notifications")
+    assert cur.fetchone()[0] == 1
+    conn.close()
+
+
+def test_llm_processor_reads_config_and_runs(tmp_path, monkeypatch):
+    db = setup_db(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE input (id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT)")
+    conn.execute("INSERT INTO input (data) VALUES ('x')")
+    conn.execute("CREATE TABLE results (id INTEGER PRIMARY KEY AUTOINCREMENT, llm_id TEXT, content TEXT)")
+    conn.execute(
+        "INSERT INTO llm_io_config (llm_id, read_tables, output_table, needs_reload) VALUES ('main_llm_processor', 'input', 'results', 0)"
+    )
+    conn.execute(
+        "INSERT INTO llm_notifications (llm_id, notification_type) VALUES ('main_llm_processor', 'RUN')"
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(llm_processor, "DB_FULL_PATH", str(db))
+    monkeypatch.setattr(llm_processor, "POLL_INTERVAL", 0)
+
+    def fake_sleep(_):
+        raise StopIteration
+
+    monkeypatch.setattr(llm_processor.time, "sleep", fake_sleep)
+    monkeypatch.setattr(sys, "argv", ["llm_processor.py"])  # avoid argparse parsing pytest args
+
+    with pytest.raises(StopIteration):
+        llm_processor.main()
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM results")
+    assert cur.fetchone()[0] >= 1
+    conn.close()


### PR DESCRIPTION
## Summary
- add llm_io_config and llm_notifications tables
- register llm_config_daemon and default io config
- implement llm_config_daemon for configuration pushes
- expand llm_processor to consume the new tables
- document new runtime configuration tables
- add tests for new components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688150335918832e8ad7065373b30916