### PR TITLE
Add payload column and notification handling for LLM

### DIFF
--- a/ClaudeREADME.md
+++ b/ClaudeREADME.md
@@ -200,6 +200,16 @@ notification to ``llm_notifications`` which causes ``llm_processor`` to reload
 its settings. A ``RUN`` notification instructs the processor to read from the
 allowed tables and write results to the designated output table.
 
+``llm_notifications`` also accepts an optional ``payload`` column. When
+``llm_config_daemon`` inserts a ``CONFIG_RELOAD`` row the payload is ``NULL``,
+but other daemons may send ``PUSH`` notifications with a comma separated list of
+tables to read immediately. ``llm_processor`` treats a ``RUN`` or ``PUSH``
+notification with a payload as an instruction to read those tables once and
+store the results. A ``PULL_REQUEST`` notification causes the processor to write
+``REQUEST:<payload>`` into its output table so external components can respond.
+This mechanism allows other daemons to trigger ad-hoc runs or for the LLM to
+ask for additional data while running.
+
 Custom Managers
 Managers should:
 

--- a/init_database.py
+++ b/init_database.py
@@ -116,6 +116,7 @@ def create_database_schema():
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 llm_id TEXT NOT NULL,
                 notification_type TEXT NOT NULL,
+                payload TEXT,
                 processed INTEGER DEFAULT 0,
                 created_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             );

--- a/llm_config_daemon.py
+++ b/llm_config_daemon.py
@@ -59,8 +59,8 @@ def main_loop(run_type: str):
         row = cur.fetchone()
         if row and row[0]:
             cur.execute(
-                f"INSERT INTO {NOTIFY_TABLE} (llm_id, notification_type) VALUES (?, ?)",
-                ('main_llm_processor', 'CONFIG_RELOAD'),
+                f"INSERT INTO {NOTIFY_TABLE} (llm_id, notification_type, payload) VALUES (?, ?, ?)",
+                ('main_llm_processor', 'CONFIG_RELOAD', None),
             )
             cur.execute(
                 f"UPDATE {CONFIG_TABLE} SET needs_reload=0 WHERE llm_id=?",


### PR DESCRIPTION
## Summary
- extend `llm_notifications` schema with a `payload` column
- understand optional payloads in `llm_processor.py`
- send `CONFIG_RELOAD` with explicit NULL payload
- document payload workflow in `ClaudeREADME.md`
- test push and pull notification handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68822d408ae0832e9c554093a24ea31e