### PR TITLE
Implement DB access logging

### DIFF
--- a/init_database.py
+++ b/init_database.py
@@ -90,6 +90,19 @@ def create_database_schema():
             );
             """
         )
+
+        # 6. db_access_log table - Records DB table read/write events
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS db_access_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                component_id TEXT,
+                table_name TEXT NOT NULL,
+                access_type TEXT NOT NULL CHECK (access_type IN ('READ', 'WRITE'))
+            );
+            """
+        )
         
         # Create indexes for better performance
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_ac_manager ON autorun_components (manager_affinity);")
@@ -99,6 +112,9 @@ def create_database_schema():
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_cll_timestamp ON component_lifecycle_log (event_timestamp);")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_temp_timestamp ON cpu_temperature_log (timestamp);")
         cursor.execute("CREATE INDEX IF NOT EXISTS idx_metrics_timestamp ON system_metrics_log (timestamp);")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_dbal_component ON db_access_log (component_id);")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_dbal_table ON db_access_log (table_name);")
+        cursor.execute("CREATE INDEX IF NOT EXISTS idx_dbal_timestamp ON db_access_log (timestamp);")
 
         # 6. llm_io_config table - runtime configuration for LLM processors
         cursor.execute("""

--- a/llm_config_daemon.py
+++ b/llm_config_daemon.py
@@ -9,7 +9,7 @@ import os
 import sqlite3
 import time
 
-from manager_utils import log_lifecycle_event
+from manager_utils import log_lifecycle_event, log_db_access
 
 DB_FILE_NAME = 'n0m1_agi.db'
 DB_FULL_PATH = os.path.expanduser(f'~/n0m1_agi/{DB_FILE_NAME}')
@@ -52,6 +52,7 @@ def main_loop(run_type: str):
     conn = sqlite3.connect(DB_FULL_PATH)
     cur = conn.cursor()
     while True:
+        log_db_access(DB_FULL_PATH, COMPONENT_ID, CONFIG_TABLE, "READ")
         cur.execute(
             f"SELECT needs_reload FROM {CONFIG_TABLE} WHERE llm_id=?",
             ('main_llm_processor',),

--- a/manager_utils.py
+++ b/manager_utils.py
@@ -171,6 +171,25 @@ def log_lifecycle_event(
         if conn:
             conn.close()
 
+def log_db_access(db_path: str, component_id: str, table: str, access_type: str) -> bool:
+    """Record a database table access event."""
+    conn = None
+    try:
+        conn = sqlite3.connect(db_path)
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO db_access_log (component_id, table_name, access_type) VALUES (?, ?, ?)",
+            (component_id, table, access_type),
+        )
+        conn.commit()
+        return True
+    except sqlite3.Error as e:
+        print(f"Database error logging db access: {e}")
+        return False
+    finally:
+        if conn:
+            conn.close()
+
 def get_component_full_status(pid_file: str, component_id: str) -> Tuple[str, Optional[int]]:
     """
     Get component status with PID.

--- a/tests/test_db_access_logging.py
+++ b/tests/test_db_access_logging.py
@@ -1,0 +1,127 @@
+import os
+import sqlite3
+import sys
+import pytest
+
+# Add repo root to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import llm_processor
+import llm_config_daemon
+import nano_instance
+
+
+def setup_db(tmp_path):
+    db_path = tmp_path / "access.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """CREATE TABLE llm_io_config (
+            llm_id TEXT PRIMARY KEY,
+            read_tables TEXT,
+            output_table TEXT,
+            needs_reload INTEGER
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE llm_notifications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            llm_id TEXT,
+            notification_type TEXT,
+            processed INTEGER DEFAULT 0,
+            created_timestamp TEXT DEFAULT CURRENT_TIMESTAMP
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE system_metrics_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT DEFAULT CURRENT_TIMESTAMP,
+            cpu_temp REAL,
+            cpu_usage REAL,
+            mem_usage REAL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE nano_outputs (
+            id INTEGER PRIMARY KEY,
+            nano_id TEXT,
+            timestamp TEXT DEFAULT CURRENT_TIMESTAMP,
+            content TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE db_access_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT DEFAULT CURRENT_TIMESTAMP,
+            component_id TEXT,
+            table_name TEXT,
+            access_type TEXT
+        )"""
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_load_config_logs_access(tmp_path, monkeypatch):
+    db = setup_db(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO llm_io_config (llm_id, read_tables, output_table, needs_reload)"
+        " VALUES ('main_llm_processor', 't', 'o', 0)"
+    )
+    conn.commit()
+
+    monkeypatch.setattr(llm_processor, "DB_FULL_PATH", str(db))
+
+    llm_processor.load_config(conn)
+
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM db_access_log WHERE table_name='llm_io_config'")
+    assert cur.fetchone()[0] == 1
+    conn.close()
+
+
+def test_llm_config_daemon_logs_access(tmp_path, monkeypatch):
+    db = setup_db(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO llm_io_config (llm_id, read_tables, output_table, needs_reload)"
+        " VALUES ('main_llm_processor', 'x', 'y', 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(llm_config_daemon, "DB_FULL_PATH", str(db))
+    monkeypatch.setattr(llm_config_daemon, "POLL_INTERVAL", 0)
+
+    def fake_sleep(_):
+        raise StopIteration
+
+    monkeypatch.setattr(llm_config_daemon.time, "sleep", fake_sleep)
+
+    with pytest.raises(StopIteration):
+        llm_config_daemon.main_loop("TEST")
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM db_access_log WHERE table_name='llm_io_config'")
+    assert cur.fetchone()[0] >= 1
+    conn.close()
+
+
+def test_nano_instance_logs_metrics_access(tmp_path, monkeypatch):
+    db = setup_db(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute("INSERT INTO system_metrics_log (cpu_temp, cpu_usage, mem_usage) VALUES (1,1,1)")
+    conn.commit()
+
+    monkeypatch.setattr(nano_instance, "DB_FULL_PATH", str(db))
+
+    rows = nano_instance.fetch_recent_metrics(conn, "system_metrics_log", "nano_test")
+
+    assert rows
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM db_access_log WHERE table_name='system_metrics_log'")
+    assert cur.fetchone()[0] == 1
+    conn.close()
+


### PR DESCRIPTION
## Summary
- add `db_access_log` table and indexes
- implement `log_db_access` helper
- track read access in major components
- expose simple tests exercising DB logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68815da9513c832ea33b63555819fe98