### PR TITLE
Add LLM command daemon

### DIFF
--- a/ClaudeREADME.md
+++ b/ClaudeREADME.md
@@ -210,6 +210,14 @@ store the results. A ``PULL_REQUEST`` notification causes the processor to write
 This mechanism allows other daemons to trigger ad-hoc runs or for the LLM to
 ask for additional data while running.
 
+LLM Command Daemon
+------------------
+The ``llm_command_daemon`` watches the ``llm_outputs`` table for rows whose
+``content`` begins with ``CMD:``. A command like ``CMD:START nano_foo`` will
+insert or update ``nano_foo`` in ``autorun_components`` with
+``desired_state='active'``. This allows the language model to start other
+components dynamically.
+
 Custom Managers
 Managers should:
 

--- a/llm_command_daemon.py
+++ b/llm_command_daemon.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Daemon that processes commands produced by the LLM."""
+import argparse
+import os
+import sqlite3
+import time
+
+from manager_utils import log_db_access
+
+DB_FILE_NAME = 'n0m1_agi.db'
+DB_FULL_PATH = os.path.expanduser(f'~/n0m1_agi/{DB_FILE_NAME}')
+OUTPUT_TABLE = 'llm_outputs'
+AUTORUN_TABLE = 'autorun_components'
+COMPONENT_ID = 'llm_command_daemon'
+POLL_INTERVAL = 5
+
+
+def handle_command(conn: sqlite3.Connection, command: str) -> None:
+    """Process a single command string."""
+    if command.startswith('CMD:START '):
+        comp_id = command[len('CMD:START '):].strip()
+        cur = conn.cursor()
+        cur.execute(
+            f"SELECT 1 FROM {AUTORUN_TABLE} WHERE component_id=?",
+            (comp_id,)
+        )
+        log_db_access(DB_FULL_PATH, COMPONENT_ID, AUTORUN_TABLE, 'READ')
+        if cur.fetchone():
+            cur.execute(
+                f"UPDATE {AUTORUN_TABLE} SET desired_state='active' WHERE component_id=?",
+                (comp_id,),
+            )
+        else:
+            cur.execute(
+                f"""INSERT INTO {AUTORUN_TABLE} (
+                    component_id, base_script_name, manager_affinity, desired_state
+                ) VALUES (?, ?, ?, 'active')""",
+                (comp_id, f'{comp_id}.py', 'daemon_manager'),
+            )
+        log_db_access(DB_FULL_PATH, COMPONENT_ID, AUTORUN_TABLE, 'WRITE')
+        conn.commit()
+
+
+def main_loop(run_type: str) -> None:
+    conn = sqlite3.connect(DB_FULL_PATH)
+    cur = conn.cursor()
+    last_id = 0
+    while True:
+        cur.execute(
+            f"SELECT id, content FROM {OUTPUT_TABLE} WHERE id>? ORDER BY id",
+            (last_id,),
+        )
+        rows = cur.fetchall()
+        log_db_access(DB_FULL_PATH, COMPONENT_ID, OUTPUT_TABLE, 'READ')
+        for row_id, content in rows:
+            last_id = row_id
+            if content and content.startswith('CMD:'):
+                handle_command(conn, content)
+                cur.execute(f"DELETE FROM {OUTPUT_TABLE} WHERE id=?", (row_id,))
+                log_db_access(DB_FULL_PATH, COMPONENT_ID, OUTPUT_TABLE, 'WRITE')
+                conn.commit()
+        time.sleep(POLL_INTERVAL)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='LLM command daemon')
+    parser.add_argument('--run_type', default='MANUAL_RUN')
+    args = parser.parse_args()
+
+    try:
+        main_loop(args.run_type)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_llm_command_daemon.py
+++ b/tests/test_llm_command_daemon.py
@@ -1,0 +1,77 @@
+import os
+import sqlite3
+import sys
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import llm_command_daemon
+
+
+def setup_db(tmp_path):
+    db = tmp_path / "test.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """CREATE TABLE llm_outputs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            llm_id TEXT,
+            timestamp TEXT DEFAULT CURRENT_TIMESTAMP,
+            content TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE autorun_components (
+            component_id TEXT PRIMARY KEY,
+            base_script_name TEXT,
+            manager_affinity TEXT,
+            desired_state TEXT
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE db_access_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT DEFAULT CURRENT_TIMESTAMP,
+            component_id TEXT,
+            table_name TEXT,
+            access_type TEXT
+        )"""
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_command_starts_component(tmp_path, monkeypatch):
+    db = setup_db(tmp_path)
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO llm_outputs (llm_id, content) VALUES (?, ?)",
+        ('main_llm_processor', 'CMD:START test_comp')
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(llm_command_daemon, 'DB_FULL_PATH', str(db))
+    monkeypatch.setattr(llm_command_daemon, 'POLL_INTERVAL', 0)
+
+    def fake_sleep(_):
+        raise StopIteration
+
+    monkeypatch.setattr(llm_command_daemon.time, 'sleep', fake_sleep)
+
+    with pytest.raises(StopIteration):
+        llm_command_daemon.main_loop('TEST')
+
+    conn = sqlite3.connect(db)
+    cur = conn.cursor()
+    cur.execute("SELECT desired_state FROM autorun_components WHERE component_id='test_comp'")
+    row = cur.fetchone()
+    cur.execute("SELECT COUNT(*) FROM db_access_log WHERE table_name='llm_outputs'")
+    reads = cur.fetchone()[0]
+    cur.execute("SELECT COUNT(*) FROM db_access_log WHERE table_name='autorun_components'")
+    writes = cur.fetchone()[0]
+    conn.close()
+
+    assert row is not None and row[0] == 'active'
+    assert reads >= 1
+    assert writes >= 1


### PR DESCRIPTION
## Summary
- create `llm_command_daemon.py` to process `CMD:` outputs from llm
- log database reads/writes through `log_db_access`
- test that commands update `autorun_components`
- document new daemon

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837e1e4ae0832ebf5bc67e7dd0b6f6