### PR TITLE
Fix llm_notifications schema string in test

### DIFF
--- a/tests/test_db_access_logging.py
+++ b/tests/test_db_access_logging.py
@@ -20,9 +20,7 @@ def setup_db(tmp_path):
     conn.execute(
         """CREATE TABLE llm_io_config (llm_id TEXT PRIMARY KEY, read_tables TEXT, output_table TEXT, needs_reload INTEGER)"""
     )
-    conn.execute(
-        """CREATE TABLE llm_notifications (id INTEGER PRIMARY KEY AUTOINCREMENT, llm_id TEXT, notification_type TEXT, payload TEXT, processed INTEGER DEFAULT 0, created_timestamp TEXT DEFAULT CURRENT_TIMESTAMP)"""
-    )
+    conn.execute("""CREATE TABLE llm_notifications (id INTEGER PRIMARY KEY AUTOINCREMENT, llm_id TEXT, notification_type TEXT, payload TEXT, processed INTEGER DEFAULT 0, created_timestamp TEXT DEFAULT CURRENT_TIMESTAMP)""")
     conn.execute(
         """CREATE TABLE system_metrics_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT DEFAULT CURRENT_TIMESTAMP, cpu_temp REAL, cpu_usage REAL, mem_usage REAL)"""
     )


### PR DESCRIPTION
## Summary
- rebased work on main (already up to date)
- used single-line CREATE TABLE statement in `setup_db`
- ran tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837e90a0c0832e90df2962148ae602