### PR TITLE
Implement llm command daemon features

### DIFF
--- a/ClaudeREADME.md
+++ b/ClaudeREADME.md
@@ -218,6 +218,9 @@ insert or update ``nano_foo`` in ``autorun_components`` with
 ``desired_state='active'``. This allows the language model to start other
 components dynamically.
 
+Run the daemon manually with ``python llm_command_daemon.py`` or add it to the
+``autorun_components`` table so ``daemon_manager`` launches it automatically.
+
 Custom Managers
 Managers should:
 


### PR DESCRIPTION
## Summary
- add test covering update of existing autorun component
- clarify how to run `llm_command_daemon` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c6830028832eae62b57c56a1978a