### PR TITLE
Add database support for nano prompts

### DIFF
--- a/ClaudeREADME.md
+++ b/ClaudeREADME.md
@@ -132,6 +132,8 @@ Example data table for the temperature daemon
 cpu_usage_log
 memory_usage_log
 Separate tables for CPU and memory usage collected by dedicated daemons
+nano_prompts
+Persistent prompt text for each nano instance (use needs_reload flag to update)
 Configuration
 Optional config.json
 json{

--- a/tests/test_db_access_logging.py
+++ b/tests/test_db_access_logging.py
@@ -27,6 +27,14 @@ def setup_db(tmp_path):
     conn.execute(
         """CREATE TABLE nano_outputs (id INTEGER PRIMARY KEY AUTOINCREMENT, nano_id TEXT, timestamp TEXT DEFAULT CURRENT_TIMESTAMP, content TEXT)"""
     )
+    conn.execute(
+        """CREATE TABLE nano_prompts (
+            nano_id TEXT PRIMARY KEY,
+            prompt TEXT NOT NULL,
+            modified_timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            needs_reload INTEGER DEFAULT 0
+        )"""
+    )
     conn.commit()
     conn.close()
     return db


### PR DESCRIPTION
## Summary
- create `nano_prompts` table in database schema
- populate default nano prompts on initialization
- load & reload nano prompts in `nano_instance`
- document `nano_prompts` table
- extend tests for prompt functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884af6f0540832e8d67d748c236d4b9