### PR TITLE
Add cross-platform subprocess helpers and Windows tests

### DIFF
--- a/ClaudeREADME.md
+++ b/ClaudeREADME.md
@@ -24,6 +24,12 @@ Dedicated daemons collect system metrics:
 `mem_usage_daemon.py` records memory usage in `memory_usage_log`.
 Nano LLMs summarize each metric into tables like `cpu_temp_summary` which the
 main LLM can then read.
+
+Windows Support
+---------------
+The process management utilities now run on Windows. Subprocesses are launched
+in their own process groups using `CREATE_NEW_PROCESS_GROUP` and terminated with
+`CTRL_BREAK_EVENT` when shutting down.
 Quick Start
 1. Initial Setup
 bash# Create virtual environment

--- a/daemon_manager.py
+++ b/daemon_manager.py
@@ -23,6 +23,7 @@ from manager_utils import (
     log_lifecycle_event,
     log_db_access,
     create_required_directories,
+    launch_subprocess,
 )
 
 # --- Configuration ---
@@ -70,12 +71,11 @@ def start_component(component_id: str, base_script_name: str, launch_args_list: 
 
     try:
         # Launch the component as a new background process
-        process = subprocess.Popen(
+        process = launch_subprocess(
             full_command,
             cwd=PROJECT_DIR,
             stdout=open(log_file, 'a'),
             stderr=open(err_file, 'a'),
-            preexec_fn=os.setsid  # Start in a new session to detach from manager
         )
         # Write the new PID to file
         write_pid_file(pid_file, process.pid)

--- a/tests/test_manager_utils.py
+++ b/tests/test_manager_utils.py
@@ -3,17 +3,24 @@ import tempfile
 import subprocess
 import sys
 import time
+import platform
+import types
+import signal
 
 import pytest
 
 # Ensure the project root is on sys.path so manager_utils can be imported
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+import manager_utils
+
 from manager_utils import (
     write_pid_file,
     read_pid_file,
     is_process_running,
     get_venv_python,
+    launch_subprocess,
+    terminate_process,
 )
 
 
@@ -47,4 +54,81 @@ def test_get_venv_python_native_env(monkeypatch, tmp_path):
     path = get_venv_python(str(tmp_path))
     assert path == sys.executable
     monkeypatch.delenv("N0M1_NATIVE", raising=False)
+
+
+def test_launch_subprocess_posix(monkeypatch):
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured.update(kwargs)
+        class P:
+            pid = 123
+        return P()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    fake_os = types.SimpleNamespace(name="posix", setsid=os.setsid)
+    monkeypatch.setattr(manager_utils, "os", fake_os)
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+
+    launch_subprocess(["echo"])
+    assert captured.get("preexec_fn") == os.setsid
+    assert "creationflags" not in captured
+
+
+def test_launch_subprocess_windows(monkeypatch):
+    captured = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured.update(kwargs)
+        class P:
+            pid = 123
+        return P()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200, raising=False)
+    fake_os = types.SimpleNamespace(name="nt")
+    monkeypatch.setattr(manager_utils, "os", fake_os)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+    launch_subprocess(["echo"])
+    assert captured.get("creationflags") == subprocess.CREATE_NEW_PROCESS_GROUP
+    assert "preexec_fn" not in captured
+
+
+def test_terminate_process_posix(monkeypatch):
+    calls = {}
+
+    def fake_killpg(pgid, sig):
+        calls["pgid"] = pgid
+        calls["sig"] = sig
+
+    fake_os = types.SimpleNamespace(name="posix", killpg=fake_killpg, getpgid=lambda pid: 42)
+    monkeypatch.setattr(manager_utils, "os", fake_os)
+
+    proc = types.SimpleNamespace(pid=1)
+    terminate_process(proc)
+    assert calls["pgid"] == 42
+    assert calls["sig"] == signal.SIGTERM
+
+
+def test_terminate_process_windows(monkeypatch):
+    signals = []
+
+    class P:
+        def __init__(self):
+            self.pid = 1
+
+        def send_signal(self, sig):
+            signals.append(sig)
+
+        def terminate(self):
+            signals.append("TERM")
+
+    fake_os = types.SimpleNamespace(name="nt")
+    monkeypatch.setattr(manager_utils, "os", fake_os)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+    monkeypatch.setattr(signal, "CTRL_BREAK_EVENT", 0, raising=False)
+    p = P()
+    terminate_process(p)
+    assert signals == [signal.CTRL_BREAK_EVENT]
 


### PR DESCRIPTION
## Summary
- add `launch_subprocess` and `terminate_process` helpers
- use helpers in daemon_manager and boot_system_enhanced
- extend unit tests to cover Windows code paths
- document Windows support in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688627e54790832e95580063fadd5bca